### PR TITLE
Replace stat with date (do it the linux way, not mac)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,14 +4,15 @@ while true; do
     for FILE in /dumps/*; do
         if [ -d $FILE ]; then
             # directory: move as is
-            rclone move $FILE remote:$S3bucket
+            DIR=$(basename $FILE)
+            rclone move $FILE remote:$S3bucket/$DIR
             RESULT=$?
             if [ $RESULT -ne 0 ]; then
                 echo "Failed to send dump dir $FILE to S3 bucket $S3bucket"
             fi
         else
             # file: move to a directory named with the file timestamp
-            TIMESTAMP=$(stat -f "%Sm" -t "%Y-%m-%d-%H-%M-%S" $FILE)
+            TIMESTAMP=$(date -r $FILE +"%Y_%m_%d_%H_%M_%S")
             rclone move $FILE remote:$S3bucket/$TIMESTAMP
             RESULT=$?
             if [ $RESULT -ne 0 ]; then

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ while true; do
             if [ $RESULT -ne 0 ]; then
                 echo "Failed to send dump dir $FILE to S3 bucket $S3bucket"
             fi
-        else
+        elif [ -f $FILE ]; then
             # file: move to a directory named with the file timestamp
             TIMESTAMP=$(date -r $FILE +"%Y_%m_%d_%H_%M_%S")
             rclone move $FILE remote:$S3bucket/$TIMESTAMP


### PR DESCRIPTION
1. Replace "stat" with "date" (do it the linux way, not mac)
2. Move files from dir to a dir on the remote
3. Avoid warnings when /dumps is empty